### PR TITLE
[feature] Rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .password
 package-lock.json
+settings.js

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ node bot.js
 ```
 
 ## Settings
-Edit the constants.js
+
+```
+cp settings-template.js settings.js
+nano settings.js
+```
 
 ## Copyright and License
 Copyright (c) 2021 freenode limited

--- a/bot.js
+++ b/bot.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const parseDuration = require('parse-duration')
 
 const Help = require('./lib/help.js');  // help text
-const constants = require('./lib/constants.js');  // constants and settings
+const constants = require('./settings.js');  // constants and settings
 const IRC = require('./lib/irc.js');  // irc client, connected
 const Mutes = require('./lib/mutes.js');
 

--- a/bot.js
+++ b/bot.js
@@ -5,6 +5,7 @@ const parseDuration = require('parse-duration')
 const Help = require('./lib/help.js');  // help text
 const constants = require('./settings.js');  // constants and settings
 const IRC = require('./lib/irc.js');  // irc client, connected
+const { IncrementBuildup, ClearUserBuildup } = require('./lib/limits.js');
 const Mutes = require('./lib/mutes.js');
 
 // Hack
@@ -14,6 +15,8 @@ app.listen(22534);
 
 // Nickslist - Stored in RAM, no logs, no leaks.
 let nicklist = [];
+
+const flood_mute_time = parseDuration(constants.FLOOD_MUTE_TIME) || constants.FLOOD_MUTE_TIME
 
 // Main listener
 IRC.addListener('raw',async (message) => {
@@ -81,8 +84,18 @@ async function parse(from,msg) {
       IRC.client.whois(from)
       break;
     default:
-      if (Mutes.IsUserMuted(from)) {
+      const isMuted = Mutes.IsUserMuted(from)
+
+      if (isMuted) {
         IRC.notice_chan(from, "You are muted.", constants.IRC_CHAN);
+        break;
+      }
+
+      const buildup = IncrementBuildup(from)
+
+      if (buildup > constants.MAX_MESSAGE_BUILDUP) {
+        ClearUserBuildup(from)
+        Mutes.MuteUser(from, flood_mute_time);
         break;
       }
 

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1,6 +1,7 @@
 const irc = require('irc');
-const constants = require('./constants.js');
 const fs = require('fs');
+
+const constants = require('../settings.js');
 
 
 class IRC {

--- a/lib/limits.js
+++ b/lib/limits.js
@@ -1,0 +1,74 @@
+const parseDuration = require('parse-duration')
+
+const settings = require('../settings')
+
+
+const buildup_map = new Map()
+const timeout_map = new Map()
+const decay_rate =
+  parseDuration(settings.BUILDUP_DECAY_RATE) || settings.BUILDUP_DECAY_RATE
+
+
+const SetTimeout = (nick) => {
+  CancelTimeout(nick)
+  const timeout = setTimeout(DecrementBuildup, decay_rate, nick)
+  timeout_map.set(nick, timeout)
+}
+
+const CancelTimeout = (nick) => {
+  const timeout = timeout_map.get(nick)
+  if (timeout) {
+    clearTimeout(timeout)
+  }
+}
+
+const IsUserFlooded = (nick) =>
+    GetUserBuildup(nick) > settings.MAX_MESSAGE_BUILDUP;
+
+const GetUserBuildup =
+  (nick) => buildup_map.get(nick) || 0
+
+const SetUserBuildup = (nick, buildup) => {
+  if (buildup <= 0) {
+    ClearUserBuildup(nick)
+  } else {
+    buildup_map.set(nick, buildup)}
+  }
+
+const ClearUserBuildup = (nick) => {
+    buildup_map.delete(nick)
+    clearTimeout(nick)
+}
+
+const IncrementBuildup = (nick) => {
+  let buildup = GetUserBuildup(nick)
+  buildup += 1
+  SetUserBuildup(nick, buildup)
+  SetTimeout(nick)
+  console.log(`${nick}++ ${buildup}`)
+  return buildup
+}
+
+const DecrementBuildup = (nick) => {
+  let buildup = GetUserBuildup(nick)
+  buildup = Math.max(0, buildup - 1)
+  if (buildup === 0) {
+    ClearUserBuildup(nick)
+  } else {
+    SetUserBuildup(nick, buildup)
+    SetTimeout(nick)
+  }
+  console.log(`${nick}-- ${buildup}`)
+  return buildup
+}
+
+module.exports = {
+  IsUserFlooded,
+  GetUserBuildup,
+  SetUserBuildup,
+  ClearUserBuildup,
+  CancelTimeout,
+  SetTimeout,
+  IncrementBuildup,
+  DecrementBuildup,
+}

--- a/lib/mutes.js
+++ b/lib/mutes.js
@@ -22,6 +22,21 @@ const IsUserMuted = (nick) => {
     return muted.has(nick.toLowerCase())
 }
 
+const MuteUser = (nick, duration) => {
+  if (IsUserMuted(nick)) return
+  const clean_nick = nick.toLowerCase()
+  muted.add(clean_nick)
+  setTimeout(ExpireMute, duration, clean_nick)
+  IRC.notice_chan(clean_nick, "You have been muted.", constants.IRC_CHAN);
+}
+
+const ExpireMute = (nick) => {
+  if (IsUserMuted(nick)) {
+    muted.delete(nick)
+    IRC.notice_chan(nick, "You have been unmuted.", constants.IRC_CHAN)
+  }
+}
+
 const HandleMuteWhois = (nicklist, nick, host) => {
     // find pending mute requests that match incoming whois info by nick of requester
     let request = null;
@@ -40,26 +55,21 @@ const HandleMuteWhois = (nicklist, nick, host) => {
     // check if matched requester has an approved hostmask
     for (const prefix of constants.MODERATOR_HOSTMASKS) {
         if (`${prefix}${nick}` === host) {
-            // find the real nickname of the requested anonymous nick to mute
-            for (const [real_nick, anon_nick] of Object.entries(nicklist)) {
-                if (anon_nick === request.muted_nick) {
-                    muted.add(real_nick.toLowerCase())
-                    setTimeout(ExpireMute, request.duration, real_nick.toLowerCase())
-                    IRC.notice_chan(real_nick, "You have been muted.", constants.IRC_CHAN);
-                }
-            }
+          // find the real nickname of the requested anonymous nick to mute
+          for (const [real_nick, anon_nick] of Object.entries(nicklist)) {
+              if (anon_nick === request.muted_nick) {
+                MuteUser(real_nick, request.duration)
+              }
+          }
         }
     }
 }
 
-const ExpireMute = (nick) => {
-    muted.delete(nick)
-    IRC.notice_chan(nick, "You have been unmuted.", constants.IRC_CHAN)
-}
-
 module.exports = {
     MuteRequest,
+    MuteUser,
     IsUserMuted,
     RegisterMuteRequest,
-    HandleMuteWhois
+    HandleMuteWhois,
+    ExpireMute,
 };

--- a/lib/mutes.js
+++ b/lib/mutes.js
@@ -1,4 +1,4 @@
-const constants = require('./constants.js');
+const constants = require('../settings.js');
 const IRC = require('./irc.js');
 
 

--- a/settings-template.js
+++ b/settings-template.js
@@ -13,6 +13,16 @@ const MODERATOR_HOSTMASKS = [
     'freenode/staff/',
 ]
 
+/* Flood protection
+
+- For every message sent, user buildup increases.
+- Build up decays over time.
+- Too much buildup results in a mute of the configured duration
+*/
+const MAX_MESSAGE_BUILDUP = 4
+const BUILDUP_DECAY_RATE = "1s"
+const FLOOD_MUTE_TIME = "3h"
+
 module.exports = {
   PASSWORD_FILE,
   IRC_SERVER,
@@ -20,6 +30,9 @@ module.exports = {
   IRC_USER,
   IRC_GECOS,
   IRC_CHAN,
-  MODERATOR_HOSTMASKS
+  MODERATOR_HOSTMASKS,
+  MAX_MESSAGE_BUILDUP,
+  BUILDUP_DECAY_RATE,
+  FLOOD_MUTE_TIME,
 }
 

--- a/settings-template.js
+++ b/settings-template.js
@@ -7,6 +7,7 @@ const IRC_NICK = "AnonChan";
 const IRC_USER = "anonchan";
 const IRC_GECOS = "Anonymous Channel";
 const IRC_CHAN = "#anonchan";
+
 const MODERATOR_HOSTMASKS = [
     'freenode/helper/',
     'freenode/staff/',


### PR DESCRIPTION
This adds a simple form of flood protection:

- Every message increases a user's "buildup"
- Buildup "decays" over time
- Too much buildup results in a mute

Added configuration variables:

- `const MAX_MESSAGE_BUILDUP = 4` : Max buildup before mute
- `const BUILDUP_DECAY_RATE = "1s"` : Rate at which 1 buildup decays
- `const FLOOD_MUTE_TIME = "3h"` : The duration of flood-induced mutes
